### PR TITLE
LIBSEARCH-22 Add native search interface for website search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     quick_search-library_website_searcher (0.1.0)
+      kaminari
       quick_search-core (~> 0)
 
 GEM
@@ -101,7 +102,7 @@ GEM
       mysql2
       nokogiri
       rails (~> 5.0)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)

--- a/app/controllers/quick_search_library_website_searcher/library_website_controller.rb
+++ b/app/controllers/quick_search_library_website_searcher/library_website_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module QuickSearchLibraryWebsiteSearcher
+  # Controller for /website page
+  class LibraryWebsiteController < ApplicationController
+    helper QuickSearch::ApplicationHelper
+    include QuickSearch::SearcherConcern
+    before_action :assign_search_params
+    layout 'quick_search_library_website_searcher/application'
+
+    def index
+      do_search
+      @results = Kaminari.paginate_array(@searcher.results, total_count: @searcher.total)
+                         .page(@page).per(@per_page)
+    end
+
+    private
+
+      def do_search
+        @searcher = QuickSearch::LibraryWebsiteSearcher.new(
+          http_client,
+          extracted_query(params_q_scrubbed),
+          @per_page,
+          @offset,
+          @page,
+          on_campus?(ip),
+          extracted_scope(params_q_scrubbed)
+        )
+        @searcher.search
+      end
+
+      def http_client
+        HTTPClient.new
+      end
+
+      def ip
+        request.remote_ip
+      end
+
+      def assign_search_params
+        params[:q] ||= ''
+        @q = params_q_scrubbed
+        @query = @q
+        @per_page = params[:per_page] || 10
+        @page = params[:page] || 1
+        @offset = @page.to_i - 1 * @per_page
+      end
+  end
+end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class="unavailable">
+  <%= link_to raw(t 'views.pagination.truncate'), '#' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,3 @@
+<li class="<%= 'current' if page.current? %>">
+  <%= link_to page, page.current? ? '#' : url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do -%>
+  <div class="pagination-centered">
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </div>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+</li>

--- a/app/views/layouts/quick_search_library_website_searcher/_header.html.erb
+++ b/app/views/layouts/quick_search_library_website_searcher/_header.html.erb
@@ -1,0 +1,84 @@
+<!-- UMD Environment Banner -->
+<%= environment_banner %>
+
+<!-- NAV bar -->
+<div class='nav-wrapper'>
+  <nav class="top-bar contain-to-grid row" data-topbar role="navigation">
+    <ul class="title-area">
+      <li class="name">
+        <h1><%= link_to t('organization_name'), '/' %></h1>
+      </li>
+      <li class="toggle-topbar menu-icon"><a href="#"><span></span></a></li>
+    </ul>
+    <section class="top-bar-section">
+      <!-- Right Nav Section -->
+      <ul class="right">
+        <li class="active">
+          <a href="https://giving.umd.edu/giving/showSchool.php?name=libraries"
+            target="_blank">
+            <svg class="umdheader-nav__icon" xmlns="http://www.w3.org/2000/svg" 
+              width="24" height="28" viewBox="0 0 35 28">
+              <title>Gift</title>
+              <path d="M16 1.4C7.937 1.4 1.4 7.937 1.4 16S7.937 30.6 16 30.6c8.063 0 14.6-6.537 14.6-14.6S24.063 1.4 16 1.4zm3.38 22.66v-2.55h2L21 13l-4.68 8.36h-.38L11.11 13l-.27 8.55h2v2.55H6.08v-2.55H8l.45-11.5H6.42V7.5h4.54l5.16 9.19 5-9.27h4.51v2.55h-2.04l.61 11.49h2v2.55z">
+              </path>
+            </svg>
+            Make A Gift
+          </a> 
+      </ul>
+    </section>
+  </nav>
+</div>
+
+<!-- Subnav -->
+<div class='subnav-wrapper row'>
+  <nav class="top-bar subtop-bar contain-to-grid row"  role="navigation">
+    <ul class="title-area">
+      <li class="name">
+        <a id='subnav-home-link' href='/'><img src="<%= asset_path "quicksearch_umd_theme/liblogo.png" %>" alt='University of Maryland Libraries' /></a>  
+      </li>
+      <li class="toggle-topbar menu-icon"><a href="#"><span></span></a></li>
+    </ul>
+    <section class="top-bar-section">
+    <!-- Right Nav Section -->
+    	<ul class="right">
+		  <li class="has-dropdown not-click"><a href="#">LIBRARIES &amp; SPACES </a>
+		   <ul class="dropdown"><li class="title back js-generated"><h5><a href="javascript:void(0)">Back</a></h5></li><li class="parent-link show-for-small"><a class="parent-link js-generated" href="#">LIBRARIES &amp; SPACES </a></li>
+			   <li><a href="/mckeldin" onclick="ga('send', 'event', 'navigation', 'main-menu', 'mck');">McKeldin Library (Main Library) </a></li>
+			   <li><a href="/architecture" onclick="ga('send', 'event', 'navigation', 'main-menu', 'arch');">Architecture Library </a></li>
+			   <li><a href="/art" onclick="ga('send', 'event', 'navigation', 'main-menu', 'art');">Art Library </a></li>
+			   <li><a href="/hornbake" onclick="ga('send', 'event', 'navigation', 'main-menu', 'hornbake');">Hornbake Library</a></li>
+			   <li><a href="/mspal" onclick="ga('send', 'event', 'navigation', 'main-menu', 'mspal');">Michelle Smith Performing Arts Library </a></li>
+			   <li><a href="http://shadygrove.umd.edu/library" onclick="ga('send', 'event', 'navigation', 'main-menu', 'priddy');" target="_blank">Priddy Library (Universities at Shady Grove) </a></li>
+			   <li><a href="/severn" onclick="ga('send', 'event', 'navigation', 'main-menu', 'severn');">Severn Library</a></li>
+			   <li><a href="/stem" onclick="ga('send', 'event', 'navigation', 'main-menu', 'stem');">STEM Library </a></li>
+			</ul>
+		  </li>
+		  <li class="has-dropdown not-click"><a href="#">FIND &amp; CITE </a>
+		   	<ul class="dropdown"><li class="title back js-generated"><h5><a href="javascript:void(0)">Back</a></h5></li><li class="parent-link show-for-small"><a class="parent-link js-generated" href="#">FIND &amp; CITE </a></li>
+		   		<li><a href="#">list</a></li>
+		   	</ul>
+		  </li>
+		  <li class="has-dropdown not-click"><a href="#">SERVICES</a>
+		  	<ul class="dropdown"><li class="title back js-generated"><h5><a href="javascript:void(0)">Back</a></h5></li><li class="parent-link show-for-small"><a class="parent-link js-generated" href="#">SERVICES</a></li>
+		   		<li><a href="#">list</a></li>
+		   	</ul>
+		  </li>
+		  <li class="has-dropdown not-click"><a href="#">I AM A...</a>
+		  	<ul class="dropdown"><li class="title back js-generated"><h5><a href="javascript:void(0)">Back</a></h5></li><li class="parent-link show-for-small"><a class="parent-link js-generated" href="#">I AM A...</a></li>
+		   		<li><a href="#">list</a></li>
+		   	</ul>
+		  </li>
+		  <li class="has-dropdown not-click"><a href="#">HELP</a>
+		    <ul class="dropdown"><li class="title back js-generated"><h5><a href="javascript:void(0)">Back</a></h5></li><li class="parent-link show-for-small"><a class="parent-link js-generated" href="#">HELP</a></li>
+		   		<li><a href="#">list</a></li>
+		   	</ul>
+		  </li>
+		  <li class="has-dropdown not-click"><a href="#">ABOUT</a>
+		  	<ul class="dropdown"><li class="title back js-generated"><h5><a href="javascript:void(0)">Back</a></h5></li><li class="parent-link show-for-small"><a class="parent-link js-generated" href="#">ABOUT</a></li>
+		   		<li><a href="#">list</a></li>
+		   	</ul>
+		  </li>
+		</ul>    
+    </section> 
+  </nav>
+</div>

--- a/app/views/layouts/quick_search_library_website_searcher/application.html.erb
+++ b/app/views/layouts/quick_search_library_website_searcher/application.html.erb
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<head>
+    <title><%= content_for(:title) %></title>
+    <meta content="ie=edge, chrome=1" http-equiv="x-ua-compatible" />
+    <!-- css -->
+    <%= stylesheet_link_tag 'application' %>
+
+    <!-- js -->
+    <%= javascript_include_tag 'application' %>
+    <%= render '/layouts/quick_search/head' %>
+    <%= render '/layouts/quick_search/google_analytics' %>
+
+    <!-- datepicker (temp) -->
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+</head>
+<body class="<%= body_class %>" data-quicksearch-ga-query="<%= strip_tags(@log_query) %>">
+<div class="off-canvas-wrap">
+<div class="inner-wrap">
+<%= render '/layouts/quick_search_library_website_searcher/header' %>
+<div id="content" role="document" class="page">
+    <main id="main-content" role="main" class="row l-main">
+        <div class="medium-12 main columns">
+            <div class="skip-link">
+                <a href="#main-content"></a>
+            </div>
+            <!-- CONTENT: enter content below this line -->
+            <div id="quicksearch">
+            <%= yield %>
+            </div>
+        </div>
+    </main>
+</div>
+<%= render '/layouts/quick_search/footer' %>
+</div>
+</div>
+<script type="text/javascript">$(function() { $('body').hide().show(); });
+window.I18n = <%= I18n.backend.send(:translations).to_json.html_safe %>
+</script>
+</body>
+</html>

--- a/app/views/quick_search_library_website_searcher/library_website/_results.html.erb
+++ b/app/views/quick_search_library_website_searcher/library_website/_results.html.erb
@@ -1,0 +1,8 @@
+<% results.each do |result| %>
+  <div class='row'>
+    <div class='medium-12 columns'>
+      <h3 class='title'><a href='<%= result.link %>'><%= result.title %></a><h3>
+      <p class='description'><%= result.description %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/quick_search_library_website_searcher/library_website/index.html.erb
+++ b/app/views/quick_search_library_website_searcher/library_website/index.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+    <div class="small-12 medium-6 large-9 columns">
+        <h1>Search Website</h1>
+    </div>
+</div>
+<%= render partial: 'layouts/quick_search/search_form' %>
+<%= render partial: 'results', locals: { results: @results } %>
+<%= paginate @results %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 QuickSearchLibraryWebsiteSearcher::Engine.routes.draw do
+  root 'library_website#index'
 end

--- a/quick_search-library_website_searcher.gemspec
+++ b/quick_search-library_website_searcher.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'LICENSE', 'Rakefile', 'README.md']
 
+  s.add_dependency 'kaminari'
   s.add_dependency 'quick_search-core', '~> 0'
   s.add_development_dependency 'rubocop', '= 0.52.1'
   # sqlite3 loaded for testing with the "dummy" application


### PR DESCRIPTION
This adds a `native search` page for the library website. The searcher
is used in the quick_search app. When users click on a the "Show More"
link they're taken to a pagniated results list in the app, not
redirected to the library website itself.

https://issues.umd.edu/browse/LIBSEARCH-22