### PR TITLE
LIBSEARCH-49. Initial implementation of Solr-based website search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     quick_search-library_website_searcher (0.1.0)
       kaminari
       quick_search-core (~> 0)
+      rsolr (= 2.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -55,7 +56,9 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     erubi (1.7.1)
-    fastimage (2.1.1)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
+    fastimage (2.1.3)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     httpclient (2.8.3)
@@ -86,8 +89,9 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     modernizr-rails (2.7.1)
+    multipart-post (2.0.0)
     mysql2 (0.5.1)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
@@ -131,6 +135,9 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.1)
+    rsolr (2.2.1)
+      builder (>= 2.1.2)
+      faraday (>= 0.9.0)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Include in your Search Results page
 <%= render_module(@library_website, 'library_website') %>
 ```
 
+# External Dependencies
+
+This searcher relies on a Solr server for generating search results. A typical
+use case is a Solr instance populated using Apache Nutch.
+
 ## Configuration
 
 The Library Website searcher requires configuration, such as specific URL to

--- a/app/controllers/quick_search_library_website_searcher/library_website_controller.rb
+++ b/app/controllers/quick_search_library_website_searcher/library_website_controller.rb
@@ -43,7 +43,7 @@ module QuickSearchLibraryWebsiteSearcher
         @query = @q
         @per_page = params[:per_page] || 10
         @page = params[:page] || 1
-        @offset = @page.to_i - 1 * @per_page
+        @offset = (@page.to_i - 1) * @per_page
       end
   end
 end

--- a/app/searchers/quick_search/library_website_searcher.rb
+++ b/app/searchers/quick_search/library_website_searcher.rb
@@ -1,39 +1,52 @@
 # frozen_string_literal: true
 
+require 'rsolr'
+
 module QuickSearch
   # QuickSearch seacher for UMD Library Website
   class LibraryWebsiteSearcher < QuickSearch::Searcher
     include QuickSearchLibraryWebsiteSearcher::Engine.routes.url_helpers
 
     def search
-      resp = @http.get(search_url)
-      @response = JSON.parse(resp.body)
-      @total = @response['totalCount']
+      search_term = http_request_queries['uri_escaped']
+      search_term = '*' if search_term.blank?
+
+      query_params = base_query_params
+      query_template = base_query_params['q_template']
+      query_term = query_template.gsub('SEARCH_TERM', search_term)
+      query_params['q'] = query_term
+
+      solr = RSolr.connect url: search_url
+      @response = solr.get 'select', params: query_params
+
+      @total = total
     end
 
     def results
       return results_list if results_list
-      @results_list = @response['resultList'].map do |value|
-        OpenStruct.new(link: get_hyperlink(value), title: get_title(value),
-                       description: get_description(value))
+      @results_list = @response['response']['docs'].map do |doc|
+        OpenStruct.new(
+          link: get_hyperlink(doc), title: get_title(doc), description: get_description(doc)
+        )
       end
 
       @results_list
     end
 
     def search_url
-      QuickSearch::Engine::LIBRARY_WEBSITE_CONFIG['search_url'] +
-        base_query_params +
-        http_request_queries['not_escaped']
+      QuickSearch::Engine::LIBRARY_WEBSITE_CONFIG['search_url']
     end
 
     def base_query_params
-      return QuickSearch::Engine::LIBRARY_WEBSITE_CONFIG['query_params'] if @per_page.blank?
-      "?pageSize=#{@per_page}&pageNumber=#{@page}&q="
+      query_params = QuickSearch::Engine::LIBRARY_WEBSITE_CONFIG['query_params']
+      return default_query_params if @per_page.blank?
+      query_params['rows'] = @per_page
+      query_params['start'] = @offset
+      query_params
     end
 
     def total
-      @response['totalCount']
+      @response['response']['numFound']
     end
 
     def loaded_link
@@ -44,28 +57,17 @@ module QuickSearch
 
       # Returns the hyperlink to use
       def get_hyperlink(result)
-        links = result['links']
-        links[0]['Link']['href'] if links.any?
+        result['url']
       end
 
       # Returns the string to use for the result title
       def get_title(result)
-        title = result['title']
-        display_name = result['displayName']
-        name = result['name']
-
-        return title if title.present?
-        return display_name if display_name.present?
-        name
+        result['title']
       end
 
       # Returns the string to use for the result description
       def get_description(result)
-        summary = result['summary']
-        description = result['description']
-
-        return summary if summary.present?
-        description
+        result['content']
       end
   end
 end

--- a/config/library_website_config.yml
+++ b/config/library_website_config.yml
@@ -4,12 +4,16 @@
 # your installation.
 #
 # <SEARCH_URL>: The URL for performing the search
-# <QUERY_PARAMS>: Any HTTP query parameters that should be included in the search
 # <WEBSITE_SEARCH_URL>: The URL for the website search page (with query parameter)
 
 defaults: &defaults
   search_url: '<SEARCH_URL>'
-  query_params: '?pageSize=3&q='
+  # Query params should be listed in "hash" format
+  query_params:
+    # The number of results to return
+    rows: 3
+    # Template for the "q" parameter. SEARCH_TERM will be replaced with the URI escaped search term
+    q_template: 'content:SEARCH_TERM'
   loaded_link: '<WEBSITE_SEARCH_URL>'
 
 development:

--- a/quick_search-library_website_searcher.gemspec
+++ b/quick_search-library_website_searcher.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'kaminari'
   s.add_dependency 'quick_search-core', '~> 0'
+  s.add_dependency 'rsolr', '2.2.1'
   s.add_development_dependency 'rubocop', '= 0.52.1'
   # sqlite3 loaded for testing with the "dummy" application
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Modified the searcher to use a Solr populated via Apache Nutch for
the search results, instead of using Hippo.

https://issues.umd.edu/browse/LIBSEARCH-49