### PR TITLE
 LIBSEARCH-54. Updated searcher to use Solr "documentContent" field

### DIFF
--- a/app/searchers/quick_search/library_website_searcher.rb
+++ b/app/searchers/quick_search/library_website_searcher.rb
@@ -67,7 +67,8 @@ module QuickSearch
 
       # Returns the string to use for the result description
       def get_description(result)
-        result['content']
+        description = result['documentContent']
+        content_tag(:div, content_tag(:p, description), class: ['block-with-text'])
       end
   end
 end

--- a/config/library_website_config.yml
+++ b/config/library_website_config.yml
@@ -12,8 +12,9 @@ defaults: &defaults
   query_params:
     # The number of results to return
     rows: 3
-    # Template for the "q" parameter. SEARCH_TERM will be replaced with the URI escaped search term
-    q_template: 'content:SEARCH_TERM'
+    # Template for the "q" parameter. SEARCH_TERM will be replaced with the
+    # URI escaped search term
+    q_template: 'text:SEARCH_TERM'
   loaded_link: '<WEBSITE_SEARCH_URL>'
 
 development:


### PR DESCRIPTION
Updated the searcher to use the Solr "documentContent" field for
displaying the summary for entries.

Also modified to use multi-line ellipsis, similar to that used in
Database Finder, to truncate long descriptions.

Also updates searcher to use "text" field in the Solr index for searching.

https://issues.umd.edu/browse/LIBSEARCH-54